### PR TITLE
term modification request: parameter fixnum

### DIFF
--- a/00. 术语表.md
+++ b/00. 术语表.md
@@ -47,9 +47,9 @@ collector and to determine when the objects would otherwise have been deallocate
 
 ## P
 
-**Parameter** 行为界限
+**Parameter** 环境参数
 
-> 用来查询或设置 Scheme 系统具体行为边界的过程
+> 向环境中注入参数绑定的过程，以供求值时使用
 
 **Procedure** 过程
 

--- a/00. 术语表.md
+++ b/00. 术语表.md
@@ -18,9 +18,7 @@
 
 > Field, A data member of a class. Unless specified otherwise, a field is not static.
 
-**Fixnum** 固定数
-
-> A fixnum is an exact integer that is small enough to fit in a machine word.
+**Fixnum** 定长数
 
 > [R<sup>6</sup>RS](http://www.r6rs.org/final/html/r6rs/r6rs-Z-H-4.html#node_sec_1.5)定义的Fixnum是-2<sup>23</sup>和2<sup>23</sup>-1之间的自然数。
 


### PR DESCRIPTION
这里只是针对 @flowingfirefly 同学提出的术语的一点小的异议，以下说一点我的小想法，不一定对。

如果仅讨论*parameter*作为参数化过程的这个“特殊”情况，它虽然与通常所指的过程参数感觉不同，但仍然是一种向环境中注入参数绑定的方式，词意上并没有不同，只是范围更加灵活，可以全局化，也可以通过`parameterize`等过程任意界定参数的作用域。(如果通过`eval`过程求值，把`eval`的第二个`environment`参数设为其他环境，可以使这些绑定失效，也验证了这类过程只是向当前环境注入绑定，所以在某些场合译作“环境参数”似乎可以，当然，也有些场合译成某某“过程”可能更好。)

所以可能没有必要把这个术语特殊化，*parameter*在这里并没有超出它的本来意义，r6rs中使用parameter这个词的地方很多，1.7.中作为过程参数，6.2.中作为形式参数而把*argument*作为实际参数，以及A.9.中显式写明*formal parameter*和*actual parameter*。本意都是参数，所以根据不同的上下文，仍译为参数，加上不同的“形式”或“作用域”修饰应该已经很灵活也很符合习惯。虽说此处讨论的是一个过程，可也并不特殊，过程句法，`let`句法也都隐含着绑定注入，其中是进行了参数绑定还是变量绑定，本质都一样，根据环境选择用词，也并不会使人迷惑，似乎也没有必要为此使用偏离习惯的写法。一如*scheme*并没有采用一个新词，而对这个过程仍然称为*parameter*。

其实我觉得，（环境）参数应该是参数更泛化的存在，而通常习惯指代的过程参数，形式参数等倒是限定作用域或形式之后的特殊情况。另外，把它作为一个固定的术语，我也不确定是否合适，我姑且提交为“环境参数”，如果不合适的话，就请不要合并这个PR了。

第二个关于*fixnum*的修改提议，因为不是*fix*数的值，而是其二进制表示的位数长度，似乎译成“定长数”更贴切一点。

因为是对别的同学的成果提出修改意见，所以为了把理由说清楚，只好把自己的看法不论对错都说出来，以方便讨论，一个小话题写了这么多，里面理解肤浅和谬误的地方，请你们多多指点。